### PR TITLE
update GPU driver selection and installation

### DIFF
--- a/Linux/install.sh
+++ b/Linux/install.sh
@@ -84,16 +84,19 @@ echo "=================================================="
 echo "           SELECT YOUR GPU DRIVER VERSION"
 echo "=================================================="
 echo ""
-echo "[1] CUDA 12.1 (Standard - Recommended for most Nvidia Graphics cards)"
-echo "[2] CUDA 12.8 (Nightly - For the latest RTX 50-Series)"
-echo "[3] CPU Only  (Slow - Not recommended for using OmniVoice, will still work with Kokoro)"
+echo "[1] CUDA 12.1 (Legacy   - driver 527+, RTX 20/30/40 series)"
+echo "[2] CUDA 12.6 (Standard - driver 560+, RTX 20/30/40 series, recommended)"
+echo "[3] CUDA 12.8 (Latest   - driver 570+, required for RTX 50-series)"
+echo "[4] CPU Only  (Slow - OmniVoice voice cloning will NOT be available)"
 echo ""
-read -p "Enter selection [1, 2, or 3]: " choice
+read -p "Enter selection [1, 2, 3, or 4]: " choice
 
 if [ "$choice" == "1" ]; then
   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121
 elif [ "$choice" == "2" ]; then
-  pip install --pre torch torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+  pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu126
+elif [ "$choice" == "3" ]; then
+  pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu128
 else
   pip install torch torchaudio
 fi

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ That's it! No manual Python or Git installation required.
     ```
 3.  Follow the on-screen prompts:
     * The script will verify **Python 3.12** and **Git** installation.
-    * Select your GPU architecture (CUDA version) when prompted to ensure the correct PyTorch drivers are downloaded.
+    * Select your CUDA version when prompted. Choose **12.6** for most cards (driver 560+), **12.1** for older drivers (527+), or **12.8** for RTX 50-series (driver 570+).
     * The script will automatically fetch the required voice models.
 
 ---

--- a/Windows/install.bat
+++ b/Windows/install.bat
@@ -69,16 +69,19 @@ echo ==================================================
 echo           SELECT YOUR GPU DRIVER VERSION
 echo ==================================================
 echo.
-echo [1] CUDA 12.1 (Standard - Recommended for most Nvidia Graphics cards)
-echo [2] CUDA 12.8 (Nightly - For the latest RTX 50-Series)
-echo [3] CPU Only  (Slow - Not recommended for using OmniVoice, will still work with Kokoro)
+echo [1] CUDA 12.1 (Legacy   - driver 527+, RTX 20/30/40 series)
+echo [2] CUDA 12.6 (Standard - driver 560+, RTX 20/30/40 series, recommended)
+echo [3] CUDA 12.8 (Latest   - driver 570+, required for RTX 50-series)
+echo [4] CPU Only  (Slow - OmniVoice voice cloning will NOT be available)
 echo.
-set /p choice="Enter selection [1, 2, or 3]: "
+set /p choice="Enter selection [1, 2, 3, or 4]: "
 
 if "%choice%"=="1" (
     pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121 --force-reinstall --no-deps
 ) else if "%choice%"=="2" (
-    pip install --pre torch torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128 --force-reinstall --no-deps
+    pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu126 --force-reinstall --no-deps
+) else if "%choice%"=="3" (
+    pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps
 ) else (
     pip install torch torchaudio
 )

--- a/installer/README.md
+++ b/installer/README.md
@@ -68,19 +68,21 @@ The wizard opens with a dark-themed GUI showing GPU auto-detection results.
 Default: `C:\Khazad-Voice-TTS`. The user can browse to change it.
 
 Disk space estimates are shown:
-- CPU (Kokoro): ~1.5 GB
-- GPU CUDA 12.1: ~4.5 GB
-- GPU CUDA 12.8: ~4.5 GB
+- CPU (Kokoro): ~3.0 GB
+- GPU CUDA 12.1: ~8.0 GB
+- GPU CUDA 12.6: ~8.0 GB
+- GPU CUDA 12.8: ~8.0 GB
 
 ### Step 3 — GPU Driver Selection
 
-The same three options from `install.bat`:
+The same four options from `install.bat`:
 
-| Option | Description | PyTorch Index |
-|--------|-------------|---------------|
-| CUDA 12.1 | Standard — most NVIDIA cards (RTX 20/30/40, GTX series) | `whl/cu121` |
-| CUDA 12.8 | Nightly — RTX 50-series | `whl/nightly/cu128` |
-| CPU Only | Kokoro TTS, no GPU needed | `whl/cpu` |
+| Option | Description | Min Driver | PyTorch Index |
+|--------|-------------|------------|---------------|
+| CUDA 12.1 | Legacy — RTX 20/30/40 series, older drivers | 527+ | `whl/cu121` |
+| CUDA 12.6 | Standard — RTX 20/30/40 series, recommended | 560+ | `whl/cu126` |
+| CUDA 12.8 | Latest — required for RTX 50-series (Blackwell) | 570+ | `whl/cu128` |
+| CPU Only | Kokoro TTS, no GPU needed | — | `whl/cpu` |
 
 If no NVIDIA GPU was detected, CPU mode is pre-selected with a warning.
 

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -34,14 +34,16 @@ DEFAULT_INSTALL_DIR = r"C:\Khazad-Voice-TTS"
 
 TORCH_INDEX_URLS = {
     1: "https://download.pytorch.org/whl/cu121",
-    2: "https://download.pytorch.org/whl/nightly/cu128",
-    3: "https://download.pytorch.org/whl/cpu",
+    2: "https://download.pytorch.org/whl/cu126",
+    3: "https://download.pytorch.org/whl/cu128",
+    4: "https://download.pytorch.org/whl/cpu",
 }
 
 TORCH_LABELS = {
     1: "CUDA 12.1",
-    2: "CUDA 12.8 (Nightly)",
-    3: "CPU Only",
+    2: "CUDA 12.6",
+    3: "CUDA 12.8",
+    4: "CPU Only",
 }
 
 # Colors
@@ -81,6 +83,7 @@ class InstallerApp:
         self.current_step = 0
         self.has_nvidia = False
         self.gpu_name: Optional[str] = None
+        self.driver_version: Optional[str] = None
         self._cancel = False
         self._install_success = False
         self._is_update = False
@@ -88,8 +91,22 @@ class InstallerApp:
         # Detect hardware
         self._detect_gpu()
 
-        # Set default choice based on detection
-        self.gpu_choice.set(1 if self.has_nvidia else 3)
+        # Set default choice based on detection and detected driver version
+        if self.has_nvidia:
+            ver = self.driver_version or ""
+            try:
+                major = int(ver.split(".")[0])
+            except ValueError:
+                major = 0
+            if major >= 570:
+                default_cuda = 3  # CUDA 12.8
+            elif major >= 560:
+                default_cuda = 2  # CUDA 12.6
+            else:
+                default_cuda = 1  # CUDA 12.1 (safe fallback)
+            self.gpu_choice.set(default_cuda)
+        else:
+            self.gpu_choice.set(4)
 
         # Set window icon (logo.ico is created at build time from logo.jpg)
         if getattr(sys, "frozen", False):
@@ -112,19 +129,28 @@ class InstallerApp:
     def _detect_gpu(self):
         """Check for an NVIDIA GPU via nvidia-smi, then WMI as fallback."""
         # Method 1: nvidia-smi (fast, but may not be on PATH)
-        try:
-            result = subprocess.run(
-                ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                self.has_nvidia = True
-                self.gpu_name = result.stdout.strip().split("\n")[0]
-                return
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        _smi_candidates = [
+            "nvidia-smi",
+            r"C:\Windows\System32\nvidia-smi.exe",
+            r"C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe",
+        ]
+        for smi in _smi_candidates:
+            try:
+                result = subprocess.run(
+                    [smi, "--query-gpu=name,driver_version", "--format=csv,noheader"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    first_line = result.stdout.strip().split("\n")[0]
+                    parts = [p.strip() for p in first_line.split(",", 1)]
+                    self.has_nvidia = True
+                    self.gpu_name = parts[0]
+                    self.driver_version = parts[1] if len(parts) > 1 else None
+                    return
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
 
         # Method 2: WMI query (built into Windows, works without nvidia-smi)
         try:
@@ -401,6 +427,14 @@ class InstallerApp:
                     fg=FG_GREEN,
                     bg=BG_PANEL,
                 ).pack(anchor=tk.W)
+                if self.driver_version:
+                    tk.Label(
+                        det_frame,
+                        text=f"  Driver version:       {self.driver_version}",
+                        font=("Segoe UI", 10),
+                        fg=FG_GREEN,
+                        bg=BG_PANEL,
+                    ).pack(anchor=tk.W)
                 tk.Label(
                     det_frame,
                     text="GPU-accelerated TTS (OmniVoice voice cloning) will be available.",
@@ -470,6 +504,7 @@ class InstallerApp:
             "Estimated disk space required (Install + AI Models):\n"
             "  CPU (Kokoro)   ~3.0 GB\n"
             "  GPU CUDA 12.1  ~8.0 GB\n"
+            "  GPU CUDA 12.6  ~8.0 GB\n"
             "  GPU CUDA 12.8  ~8.0 GB"
         )
         tk.Label(
@@ -521,18 +556,24 @@ class InstallerApp:
         options = [
             (
                 1,
-                "CUDA 12.1  -  Standard",
-                "Recommended for most NVIDIA graphics cards.\n"
-                "Works with RTX 20/30/40 series and older GTX cards.",
+                "CUDA 12.1  -  Legacy",
+                "For older NVIDIA cards or systems with an older driver.\n"
+                "Compatible with RTX 20/30/40 series (driver 527+).",
             ),
             (
                 2,
-                "CUDA 12.8  -  Nightly",
-                "For the latest RTX 50-series cards.\n"
-                "Uses PyTorch nightly build (required for RTX 50-series).",
+                "CUDA 12.6  -  Standard",
+                "Recommended for most NVIDIA graphics cards.\n"
+                "Compatible with RTX 20/30/40 series (driver 560+).",
             ),
             (
                 3,
+                "CUDA 12.8  -  Latest",
+                "Required for RTX 50-series (Blackwell) cards.\n"
+                "Also works on RTX 20/30/40 series with a recent driver (570+).",
+            ),
+            (
+                4,
                 "CPU Only  -  Kokoro",
                 "No GPU required. Fast and reliable TTS.\n"
                 "OmniVoice (voice cloning) will NOT be available.",
@@ -968,7 +1009,7 @@ class InstallerApp:
         try:
             install_path = Path(self.install_dir.get())
             choice = self.gpu_choice.get()
-            use_gpu = choice in (1, 2)
+            use_gpu = choice in (1, 2, 3)
 
             # ── Step 1: Acquire uv ──
             self._set_status("Setting up uv package manager...")


### PR DESCRIPTION
This pull request updates the installer scripts and documentation to improve GPU driver and CUDA version selection, add support for CUDA 12.6, and enhance auto-detection of the user's GPU and driver version. The changes clarify installation options for different NVIDIA driver versions and hardware, and ensure the correct PyTorch packages are installed for each scenario.

**Installer and Hardware Detection Improvements:**

* Added support for CUDA 12.6 as the new recommended default for most RTX 20/30/40 series GPUs, with improved auto-detection of the installed NVIDIA driver version to pre-select the optimal CUDA version in the installer UI. The installer now distinguishes between CUDA 12.1 (legacy), 12.6 (recommended), and 12.8 (latest/RTX 50-series), and displays the detected driver version to the user.

* Updated disk space estimates and option descriptions in both the GUI and documentation to reflect the new CUDA versions and their requirements.

**Script and Batch File Updates:**

* Modified both `Linux/install.sh` and `Windows/install.bat` to include the new CUDA 12.6 option, update the CUDA version descriptions and requirements, and ensure the correct PyTorch wheels are installed for each selection. CPU-only mode is now clearly noted as incompatible with OmniVoice voice cloning.

* Updated the mapping of CUDA options and labels in `installer/setup.py` to match the new structure and ensure consistency across platforms.

**Documentation Updates:**

* Clarified the CUDA version selection process and requirements in both the main `README.md` and the installer documentation, guiding users to choose the correct option based on their GPU and driver version.

**Other Notable Changes:**

* Ensured that GPU-accelerated TTS is enabled for all CUDA options (12.1, 12.6, 12.8), and CPU-only mode is clearly separated as a fourth option throughout the installer logic.