### PR TITLE
initialize dropdowns with first category and sample

### DIFF
--- a/src/voice_lab/ui.py
+++ b/src/voice_lab/ui.py
@@ -156,13 +156,16 @@ def create_ui() -> gr.Blocks:
                     with gr.Column():
                         # Library Group
                         with gr.Group(visible=True) as grp_library:
+                            _initial_categories = lib.get_library_categories()
+                            _initial_category = _initial_categories[0] if _initial_categories else None
                             lib_category = gr.Dropdown(
-                                choices=lib.get_library_categories(),
+                                choices=_initial_categories,
+                                value=_initial_category,
                                 label="STEP 1: Pick a voice category",
                                 interactive=True,
                             )
                             lib_sample = gr.Dropdown(
-                                choices=[],
+                                choices=lib.get_samples_for_category(_initial_category) if _initial_category else [],
                                 label="STEP 2: Select Sample File",
                                 interactive=True,
                             )
@@ -280,8 +283,10 @@ def create_ui() -> gr.Blocks:
 
                 # 3. Library Handling
                 def update_samples(cat):
+                    samples = lib.get_samples_for_category(cat)
                     return gr.Dropdown(
-                        choices=lib.get_samples_for_category(cat), value=None
+                        choices=samples,
+                        value=samples[0] if samples else None,
                     )
 
                 lib_category.change(


### PR DESCRIPTION
Fixes issue https://github.com/Thelukepet/Khazad-Voice-TTS/issues/28
---
This pull request improves the user experience when selecting voice samples from the library in the UI. The main changes ensure that the dropdowns for categories and samples are initialized with appropriate default values and update more intuitively when the category changes.

**UI initialization improvements:**

* The `lib_category` dropdown is now initialized with the first available category selected by default, if any exist. The `lib_sample` dropdown is also initialized with the samples from this category, or left empty if no categories are available.

**Dropdown update behavior:**

* When the user selects a new category, the `lib_sample` dropdown now updates its choices to the samples in the selected category and automatically selects the first sample if available.