### PR TITLE
add script log path detection for windows

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,8 @@ import os
 import sys
 from pathlib import Path
 
+from .path_utils import detect_script_log_path
+
 # --- PATHS ---
 BASE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = BASE_DIR / "data"
@@ -54,9 +56,7 @@ DEFAULT_ECHOES_OFFSETS = {
 }
 
 # Retail Mode Paths
-SCRIPT_LOG = os.path.join(
-    os.path.expanduser("~"), "Documents", "The Lord of the Rings Online", "Script.log"
-)
+SCRIPT_LOG = detect_script_log_path()
 TEMPLATES_DIR = BASE_DIR / "templates"
 
 # --- DEVICE ---

--- a/src/path_utils.py
+++ b/src/path_utils.py
@@ -1,0 +1,56 @@
+# Imports
+
+# > Standard Library
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+def _get_windows_documents_dirs() -> Iterable[Path]:
+    """Return Windows Documents directories resolved from known-folder settings."""
+    seen: set[str] = set()
+
+    def add(path: Path | None):
+        if not path:
+            return
+        normalized = str(path)
+        if normalized in seen:
+            return
+        seen.add(normalized)
+        yield_path.append(path)
+
+    yield_path: list[Path] = []
+
+    try:
+        import winreg
+
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",
+        ) as key:
+            docs, _ = winreg.QueryValueEx(key, "Personal")
+            add(Path(os.path.expandvars(docs)))
+    except Exception:
+        pass
+
+    return yield_path
+
+
+def detect_script_log_path() -> str:
+    """Resolve the LOTRO Script.log path for the current platform."""
+    lotro_rel = Path("The Lord of the Rings Online") / "Script.log"
+
+    if sys.platform != "win32":
+        return str(Path.home() / "Documents" / lotro_rel)
+
+    doc_dirs = list(_get_windows_documents_dirs())
+    for docs in doc_dirs:
+        candidate = docs / lotro_rel
+        if candidate.exists():
+            return str(candidate)
+
+    if doc_dirs:
+        return str(doc_dirs[0] / lotro_rel)
+
+    return str(Path.home() / "Documents" / lotro_rel)


### PR DESCRIPTION
This pull request refactors how the application determines the location of the `Script.log` file, making the logic more robust and platform-aware (partial fix for https://github.com/Thelukepet/Khazad-Voice-TTS/issues/31). The main improvement is moving hardcoded path logic out of `config.py` into a new utility function that can better handle different user environments, especially on Windows.

**Path detection improvements:**

* Introduced a new `detect_script_log_path()` function in `path_utils.py` that intelligently locates the `Script.log` file, using Windows registry information when available and falling back to sensible defaults otherwise.
* Replaced the hardcoded `SCRIPT_LOG` path in `config.py` with a call to `detect_script_log_path()`, ensuring the application uses the correct log file location across platforms.
* Added an import for `detect_script_log_path` in `config.py` to support the new dynamic path resolution.